### PR TITLE
🐛 Fix: Website time bug when editing

### DIFF
--- a/src/backoffice/Websites/WebsiteForm.tsx
+++ b/src/backoffice/Websites/WebsiteForm.tsx
@@ -71,7 +71,7 @@ const WebsiteForm: FC<WebsiteFormProps> = ({ eventId, secretCode, maybeEvent }) 
   };
 
   const formatTime = (date: Date): string => {
-    return format(date, 'hh:mm');
+    return format(date, 'HH:mm');
   };
 
   const setWebsite = (website?: Website): void => {


### PR DESCRIPTION
# Summary

- Fix bug when edit the website, the time is changed from 24 hr clock to 12 hr clock, or, at least, the time is changing.
# Use case (Website with hour 14:16 (2:16PM))
## Before
**Edge**
![image](https://user-images.githubusercontent.com/3915121/133844560-b17ea5d0-7496-4a61-bd65-8d335a7d8832.png)
**Chrome**
![image](https://user-images.githubusercontent.com/3915121/133844592-f40ddce6-f174-450e-9397-c46f43e0d599.png)
## After
**Edge**
![image](https://user-images.githubusercontent.com/3915121/133844384-5411d719-ef3a-45ad-a0be-ea8920b87f98.png)
**Chrome**
![image](https://user-images.githubusercontent.com/3915121/133844415-f077dc22-492d-4da3-8a36-c7d1430ff88a.png)
